### PR TITLE
Add new events, reinvest and rebalance

### DIFF
--- a/contracts/CellarPoolShare.sol
+++ b/contracts/CellarPoolShare.sol
@@ -486,6 +486,7 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
         }
 
         (uint256 investedAmount0, uint256 investedAmount1) = invest();
+
         emit Rebalance(fee0, fee1, investedAmount0, investedAmount1);
     }
 

--- a/contracts/CellarPoolShare.sol
+++ b/contracts/CellarPoolShare.sol
@@ -258,7 +258,7 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
     ) external override nonReentrant notLocked(msg.sender) {
         lock(msg.sender);
         require(block.timestamp <= cellarParams.deadline);
-        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum) =
+        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, , ) =
             _removeLiquidity(cellarParams);
         _burn(msg.sender, cellarParams.tokenAmount);
 
@@ -291,7 +291,7 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
     {
         lock(msg.sender);
         require(block.timestamp <= cellarParams.deadline);
-        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum) =
+        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, , ) =
             _removeLiquidity(cellarParams);
         _burn(msg.sender, cellarParams.tokenAmount);
 
@@ -309,7 +309,13 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
         );
     }
 
-    function invest() private {
+    function invest()
+        private
+        returns (
+            uint256 totalInAmount0,
+            uint256 totalInAmount1
+        )
+    {
         uint256 balance0 = IERC20(token0).balanceOf(address(this));
         uint256 balance1 = IERC20(token1).balanceOf(address(this));
 
@@ -326,6 +332,10 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
             );
         balance0 -= inAmount0;
         balance1 -= inAmount1;
+
+        totalInAmount0 += inAmount0
+        totalInAmount1 += inAmount1
+
         (uint160 sqrtPriceX96, , , , , , ) =
             IUniswapV3Pool(
                 IUniswapV3Factory(UNISWAPV3FACTORY).getPool(
@@ -396,16 +406,20 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
 
         balance0 = IERC20(token0).balanceOf(address(this));
         balance1 = IERC20(token1).balanceOf(address(this));
-        _addLiquidity(
-            CellarAddParams({
-                amount0Desired: balance0,
-                amount1Desired: balance1,
-                amount0Min: 0,
-                amount1Min: 0,
-                recipient: address(this),
-                deadline: type(uint256).max
-            })
-        );
+        (inAmount0, inAmount1, , ) =
+            _addLiquidity(
+                CellarAddParams({
+                    amount0Desired: balance0,
+                    amount1Desired: balance1,
+                    amount0Min: 0,
+                    amount1Min: 0,
+                    recipient: address(this),
+                    deadline: type(uint256).max
+                })
+            );
+        
+        totalInAmount0 += inAmount0
+        totalInAmount1 += inAmount1
     }
 
     function reinvest() external override onlyValidator notLocked(msg.sender) {
@@ -437,7 +451,9 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
             IERC20(token1).safeTransfer(_owner, fee1);
         }
 
-        invest();
+        (uint256 investedAmount0, uint256 investedAmount1) = invest();
+
+        emit Reinvest(fee0, fee1, investedAmount0, investedAmount1)
     }
 
     function rebalance(CellarTickInfo[] memory _cellarTickInfo) external notLocked(msg.sender) {
@@ -450,7 +466,8 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
                 recipient: address(this),
                 deadline: type(uint256).max
             });
-        _removeLiquidity(removeParams);
+        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, uint256 fee0, uint256 fee1) =
+            _removeLiquidity(removeParams);
         CellarTickInfo[] memory _oldCellarTickInfo = cellarTickInfo;
         for (uint256 i = 0; i < _oldCellarTickInfo.length; i++) {
             INonfungiblePositionManager(NONFUNGIBLEPOSITIONMANAGER).burn(
@@ -468,7 +485,8 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
             cellarTickInfo.push(_cellarTickInfo[i]);
         }
 
-        invest();
+        (uint256 investedAmount0, uint256 investedAmount1) = invest();
+        emit Rebalance(fee0, fee1, investedAmount0, investedAmount1)
     }
 
     function setValidator(address _validator, bool value) external override {
@@ -897,12 +915,12 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
         returns (
             uint256 outAmount0,
             uint256 outAmount1,
-            uint128 liquiditySum
+            uint128 liquiditySum,
+            uint256 fee0,
+            uint256 fee1
         )
     {
         CellarTickInfo[] memory _cellarTickInfo = cellarTickInfo;
-        uint256 fee0;
-        uint256 fee1;
         for (uint16 i = 0; i < _cellarTickInfo.length; i++) {
             (, , , , , , , uint128 liquidity, , , , ) =
                 INonfungiblePositionManager(NONFUNGIBLEPOSITIONMANAGER)

--- a/contracts/CellarPoolShare.sol
+++ b/contracts/CellarPoolShare.sol
@@ -333,8 +333,8 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
         balance0 -= inAmount0;
         balance1 -= inAmount1;
 
-        totalInAmount0 += inAmount0
-        totalInAmount1 += inAmount1
+        totalInAmount0 += inAmount0;
+        totalInAmount1 += inAmount1;
 
         (uint160 sqrtPriceX96, , , , , , ) =
             IUniswapV3Pool(
@@ -417,9 +417,9 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
                     deadline: type(uint256).max
                 })
             );
-        
-        totalInAmount0 += inAmount0
-        totalInAmount1 += inAmount1
+
+        totalInAmount0 += inAmount0;
+        totalInAmount1 += inAmount1;
     }
 
     function reinvest() external override onlyValidator notLocked(msg.sender) {
@@ -453,7 +453,7 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
 
         (uint256 investedAmount0, uint256 investedAmount1) = invest();
 
-        emit Reinvest(fee0, fee1, investedAmount0, investedAmount1)
+        emit Reinvest(fee0, fee1, investedAmount0, investedAmount1);
     }
 
     function rebalance(CellarTickInfo[] memory _cellarTickInfo) external notLocked(msg.sender) {
@@ -486,7 +486,7 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
         }
 
         (uint256 investedAmount0, uint256 investedAmount1) = invest();
-        emit Rebalance(fee0, fee1, investedAmount0, investedAmount1)
+        emit Rebalance(fee0, fee1, investedAmount0, investedAmount1);
     }
 
     function setValidator(address _validator, bool value) external override {

--- a/contracts/CellarPoolShareLimitETHUSDT.sol
+++ b/contracts/CellarPoolShareLimitETHUSDT.sol
@@ -495,7 +495,8 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
                 recipient: address(this),
                 deadline: type(uint256).max
             });
-        _removeLiquidity(removeParams);
+        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, uint256 fee0, uint256 fee1) =
+            _removeLiquidity(removeParams);
         CellarTickInfo[] memory _oldCellarTickInfo = cellarTickInfo;
         for (uint256 i = 0; i < _oldCellarTickInfo.length; i++) {
             INonfungiblePositionManager(NONFUNGIBLEPOSITIONMANAGER).burn(

--- a/contracts/CellarPoolShareLimitETHUSDT.sol
+++ b/contracts/CellarPoolShareLimitETHUSDT.sol
@@ -287,7 +287,7 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
     ) external override nonReentrant notLocked(msg.sender) {
         lock(msg.sender);
         require(block.timestamp <= cellarParams.deadline);
-        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum) =
+        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, , ) =
             _removeLiquidity(cellarParams);
         _burn(msg.sender, cellarParams.tokenAmount);
 
@@ -320,7 +320,7 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
     {
         lock(msg.sender);
         require(block.timestamp <= cellarParams.deadline);
-        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum) =
+        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, , ) =
             _removeLiquidity(cellarParams);
         _burn(msg.sender, cellarParams.tokenAmount);
 
@@ -338,7 +338,13 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
         );
     }
 
-    function invest() private {
+    function invest()
+        private
+        returns (
+            uint256 totalInAmount0,
+            uint256 totalInAmount1
+        )
+    {
         uint256 balance0 = IERC20(token0).balanceOf(address(this));
         uint256 balance1 = IERC20(token1).balanceOf(address(this));
 
@@ -355,6 +361,10 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
             );
         balance0 -= inAmount0;
         balance1 -= inAmount1;
+
+        totalInAmount0 += inAmount0;
+        totalInAmount1 += inAmount1;
+
         (uint160 sqrtPriceX96, , , , , , ) =
             IUniswapV3Pool(
                 IUniswapV3Factory(UNISWAPV3FACTORY).getPool(
@@ -425,16 +435,20 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
 
         balance0 = IERC20(token0).balanceOf(address(this));
         balance1 = IERC20(token1).balanceOf(address(this));
-        _addLiquidity(
-            CellarAddParams({
-                amount0Desired: balance0,
-                amount1Desired: balance1,
-                amount0Min: 0,
-                amount1Min: 0,
-                recipient: address(this),
-                deadline: type(uint256).max
-            })
-        );
+        (inAmount0, inAmount1, , ) =
+            _addLiquidity(
+                CellarAddParams({
+                    amount0Desired: balance0,
+                    amount1Desired: balance1,
+                    amount0Min: 0,
+                    amount1Min: 0,
+                    recipient: address(this),
+                    deadline: type(uint256).max
+                })
+            );
+
+        totalInAmount0 += inAmount0;
+        totalInAmount1 += inAmount1;
     }
 
     function reinvest() external override onlyValidator notLocked(msg.sender) {
@@ -466,7 +480,9 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
             IERC20(token1).safeTransfer(_owner, fee1);
         }
 
-        invest();
+        (uint256 investedAmount0, uint256 investedAmount1) = invest();
+
+        emit Reinvest(fee0, fee1, investedAmount0, investedAmount1);
     }
 
     function rebalance(CellarTickInfo[] memory _cellarTickInfo) external notLocked(msg.sender) {
@@ -497,7 +513,9 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
             cellarTickInfo.push(_cellarTickInfo[i]);
         }
 
-        invest();
+        (uint256 investedAmount0, uint256 investedAmount1) = invest();
+
+        emit Rebalance(fee0, fee1, investedAmount0, investedAmount1);
     }
 
     function setValidator(address _validator, bool value) external override {
@@ -926,12 +944,12 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
         returns (
             uint256 outAmount0,
             uint256 outAmount1,
-            uint128 liquiditySum
+            uint128 liquiditySum,
+            uint256 fee0,
+            uint256 fee1
         )
     {
         CellarTickInfo[] memory _cellarTickInfo = cellarTickInfo;
-        uint256 fee0;
-        uint256 fee1;
         for (uint16 i = 0; i < _cellarTickInfo.length; i++) {
             (, , , , , , , uint128 liquidity, , , , ) =
                 INonfungiblePositionManager(NONFUNGIBLEPOSITIONMANAGER)

--- a/contracts/CellarPoolShareLimitUSDCETH.sol
+++ b/contracts/CellarPoolShareLimitUSDCETH.sol
@@ -495,7 +495,8 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
                 recipient: address(this),
                 deadline: type(uint256).max
             });
-        _removeLiquidity(removeParams);
+        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, uint256 fee0, uint256 fee1) =
+            _removeLiquidity(removeParams);
         CellarTickInfo[] memory _oldCellarTickInfo = cellarTickInfo;
         for (uint256 i = 0; i < _oldCellarTickInfo.length; i++) {
             INonfungiblePositionManager(NONFUNGIBLEPOSITIONMANAGER).burn(

--- a/contracts/CellarPoolShareLimitUSDCETH.sol
+++ b/contracts/CellarPoolShareLimitUSDCETH.sol
@@ -287,7 +287,7 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
     ) external override nonReentrant notLocked(msg.sender) {
         lock(msg.sender);
         require(block.timestamp <= cellarParams.deadline);
-        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum) =
+        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, , ) =
             _removeLiquidity(cellarParams);
         _burn(msg.sender, cellarParams.tokenAmount);
 
@@ -320,7 +320,7 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
     {
         lock(msg.sender);
         require(block.timestamp <= cellarParams.deadline);
-        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum) =
+        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, , ) =
             _removeLiquidity(cellarParams);
         _burn(msg.sender, cellarParams.tokenAmount);
 
@@ -338,7 +338,13 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
         );
     }
 
-    function invest() private {
+    function invest()
+        private
+        returns (
+            uint256 totalInAmount0,
+            uint256 totalInAmount1
+        )
+    {
         uint256 balance0 = IERC20(token0).balanceOf(address(this));
         uint256 balance1 = IERC20(token1).balanceOf(address(this));
 
@@ -355,6 +361,10 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
             );
         balance0 -= inAmount0;
         balance1 -= inAmount1;
+
+        totalInAmount0 += inAmount0;
+        totalInAmount1 += inAmount1;
+
         (uint160 sqrtPriceX96, , , , , , ) =
             IUniswapV3Pool(
                 IUniswapV3Factory(UNISWAPV3FACTORY).getPool(
@@ -425,16 +435,20 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
 
         balance0 = IERC20(token0).balanceOf(address(this));
         balance1 = IERC20(token1).balanceOf(address(this));
-        _addLiquidity(
-            CellarAddParams({
-                amount0Desired: balance0,
-                amount1Desired: balance1,
-                amount0Min: 0,
-                amount1Min: 0,
-                recipient: address(this),
-                deadline: type(uint256).max
-            })
-        );
+        (inAmount0, inAmount1, , ) =
+            _addLiquidity(
+                CellarAddParams({
+                    amount0Desired: balance0,
+                    amount1Desired: balance1,
+                    amount0Min: 0,
+                    amount1Min: 0,
+                    recipient: address(this),
+                    deadline: type(uint256).max
+                })
+            );
+
+        totalInAmount0 += inAmount0;
+        totalInAmount1 += inAmount1;
     }
 
     function reinvest() external override onlyValidator notLocked(msg.sender) {
@@ -466,7 +480,9 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
             IERC20(token1).safeTransfer(_owner, fee1);
         }
 
-        invest();
+        (uint256 investedAmount0, uint256 investedAmount1) = invest();
+
+        emit Reinvest(fee0, fee1, investedAmount0, investedAmount1);
     }
 
     function rebalance(CellarTickInfo[] memory _cellarTickInfo) external notLocked(msg.sender) {
@@ -497,7 +513,9 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
             cellarTickInfo.push(_cellarTickInfo[i]);
         }
 
-        invest();
+        (uint256 investedAmount0, uint256 investedAmount1) = invest();
+
+        emit Rebalance(fee0, fee1, investedAmount0, investedAmount1);
     }
 
     function setValidator(address _validator, bool value) external override {
@@ -926,12 +944,12 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
         returns (
             uint256 outAmount0,
             uint256 outAmount1,
-            uint128 liquiditySum
+            uint128 liquiditySum,
+            uint256 fee0,
+            uint256 fee1
         )
     {
         CellarTickInfo[] memory _cellarTickInfo = cellarTickInfo;
-        uint256 fee0;
-        uint256 fee1;
         for (uint16 i = 0; i < _cellarTickInfo.length; i++) {
             (, , , , , , , uint128 liquidity, , , , ) =
                 INonfungiblePositionManager(NONFUNGIBLEPOSITIONMANAGER)

--- a/contracts/interfaces.sol
+++ b/contracts/interfaces.sol
@@ -566,6 +566,20 @@ interface ICellarPoolShare is IERC20 {
         uint256 amount1
     );
 
+    event Reinvest (
+        uint256 fees0,
+        uint256 fees1,
+        uint256 amount0,
+        uint256 amount1
+    );
+
+    event Rebalance (
+        uint256 fees0,
+        uint256 fees1,
+        uint256 amount0,
+        uint256 amount1
+    );
+
     function addLiquidityForUniV3(CellarAddParams calldata cellarParams)
         external;
 


### PR DESCRIPTION
Initial PR that will add two new events to help track cellar TVL and fees collected in the subgraph. To achieve this I had to make the following changes:
- `_removeLiquidity` now returns `fee0` and `fee1` which are the accumulated fees collected multiplied by the fee rate and divided by the fee denom
- `invest` now returns `investedAmount0` and `investedAmount1` which tallies up the total invested amount for each token (including any swaps)
- `rebalance` and `reinvest` now emit their respective events

If this approach looks good, then I will hand it off to Steven to optimize. We could remove burning NFLPs when removing liquidity.

```js
Reinvest & Rebalance
{
  fees0: uint256, // token 0 fees collected
  fees1: uint256, // token 1 fees collected
  amount0: uint256, // token 0 amount invested
  amount1: uint256 // token 1 amount invested
}
```