### PR TITLE
introduce getCellarTickInfo

### DIFF
--- a/contracts/CellarPoolShare.sol
+++ b/contracts/CellarPoolShare.sol
@@ -543,6 +543,15 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
         return _allowances[owner_][spender];
     }
 
+    function getCellarTickInfo()
+        external
+        view
+        override
+        returns (CellarTickInfo[] memory)
+    {
+        return cellarTickInfo;
+    }
+
     function _transfer(
         address sender,
         address recipient,

--- a/contracts/CellarPoolShareLimitETHUSDT.sol
+++ b/contracts/CellarPoolShareLimitETHUSDT.sol
@@ -572,6 +572,15 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
         return _allowances[owner_][spender];
     }
 
+    function getCellarTickInfo()
+        external
+        view
+        override
+        returns (CellarTickInfo[] memory)
+    {
+        return cellarTickInfo;
+    }
+
     function _transfer(
         address sender,
         address recipient,

--- a/contracts/CellarPoolShareLimitUSDCETH.sol
+++ b/contracts/CellarPoolShareLimitUSDCETH.sol
@@ -572,6 +572,15 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
         return _allowances[owner_][spender];
     }
 
+    function getCellarTickInfo()
+        external
+        view
+        override
+        returns (CellarTickInfo[] memory)
+    {
+        return cellarTickInfo;
+    }
+
     function _transfer(
         address sender,
         address recipient,

--- a/contracts/interfaces.sol
+++ b/contracts/interfaces.sol
@@ -608,6 +608,8 @@ interface ICellarPoolShare is IERC20 {
 
     function symbol() external view returns (string memory);
 
+    function getCellarTickInfo() external view returns (CellarTickInfo[] memory);
+
     function decimals() external pure returns (uint8);
 }
 


### PR DESCRIPTION
Adds a function that will return the full `cellarTickInfo` array. This will allow contract interactions from web3 and the subgraph to avoid a loop in order to fetch cellar positions.