### PR TITLE
Update reinvest and rebalance events to emit collectedFee

### DIFF
--- a/contracts/CellarPoolShare.sol
+++ b/contracts/CellarPoolShare.sol
@@ -420,9 +420,21 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
         fee1 += perfFee1;
         if (fee0 > balance0) {
             fee0 = balance0;
+            if (mgmtFee0 < balance0) {
+                perfFee0 = balance0 - mgmtFee0;
+            } else {
+                mgmtFee0 = balance0;
+                perfFee0 = 0;
+            }
         }
         if (fee1 > balance1) {
             fee1 = balance1;
+            if (mgmtFee1 < balance1) {
+                perfFee1 = balance1 - mgmtFee1;
+            } else {
+                mgmtFee1 = balance1;
+                perfFee1 = 0;
+            }
         }
         lastManageTimestamp = block.timestamp;
         if (fee0 > 0) {

--- a/contracts/CellarPoolShare.sol
+++ b/contracts/CellarPoolShare.sol
@@ -473,9 +473,21 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
         uint256 fee1 = cellarFees.management1 + cellarFees.performance1;
         if (fee0 > cellarFees.collect0) {
             fee0 = cellarFees.collect0;
+            if (cellarFees.management0 < cellarFees.collect0) {
+                cellarFees.performance0 = cellarFees.collect0 - cellarFees.management0;
+            } else {
+                cellarFees.management0 = cellarFees.collect0;
+                cellarFees.performance0 = 0;
+            }
         }
         if (fee1 > cellarFees.collect1) {
             fee1 = cellarFees.collect1;
+            if (cellarFees.management1 < cellarFees.collect1) {
+                cellarFees.performance1 = cellarFees.collect1 - cellarFees.management1;
+            } else {
+                cellarFees.management1 = cellarFees.collect1;
+                cellarFees.performance1 = 0;
+            }
         }
 
         if (fee0 > 0) {

--- a/contracts/CellarPoolShare.sol
+++ b/contracts/CellarPoolShare.sol
@@ -464,10 +464,10 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
                 recipient: address(this),
                 deadline: type(uint256).max
             });
-        lastManageTimestamp = block.timestamp;
 
         (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, CellarFees memory cellarFees) =
             _removeLiquidity(removeParams);
+        lastManageTimestamp = block.timestamp;
 
         uint256 fee0 = cellarFees.management0 + cellarFees.performance0;
         uint256 fee1 = cellarFees.management1 + cellarFees.performance1;

--- a/contracts/CellarPoolShare.sol
+++ b/contracts/CellarPoolShare.sol
@@ -1029,8 +1029,8 @@ contract CellarPoolShare is ICellarPoolShare, BlockLock {
             cellarFees.management1 += amount.b;
         }
 
-        cellarFees.performance0 += (cellarFees.collect0 * performanceFee) / FEEDOMINATOR;
-        cellarFees.performance1 += (cellarFees.collect1 * performanceFee) / FEEDOMINATOR;
+        cellarFees.performance0 = (cellarFees.collect0 * performanceFee) / FEEDOMINATOR;
+        cellarFees.performance1 = (cellarFees.collect1 * performanceFee) / FEEDOMINATOR;
     }
 
     function _beforeTokenTransfer(

--- a/contracts/CellarPoolShareLimitETHUSDT.sol
+++ b/contracts/CellarPoolShareLimitETHUSDT.sol
@@ -1047,8 +1047,8 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
             cellarFees.management1 += amount.b;
         }
 
-        cellarFees.performance0 += (cellarFees.collect0 * performanceFee) / FEEDOMINATOR;
-        cellarFees.performance1 += (cellarFees.collect1 * performanceFee) / FEEDOMINATOR;
+        cellarFees.performance0 = (cellarFees.collect0 * performanceFee) / FEEDOMINATOR;
+        cellarFees.performance1 = (cellarFees.collect1 * performanceFee) / FEEDOMINATOR;
     }
 
     function _beforeTokenTransfer(

--- a/contracts/CellarPoolShareLimitETHUSDT.sol
+++ b/contracts/CellarPoolShareLimitETHUSDT.sol
@@ -491,9 +491,21 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
         uint256 fee1 = cellarFees.management1 + cellarFees.performance1;
         if (fee0 > cellarFees.collect0) {
             fee0 = cellarFees.collect0;
+            if (cellarFees.management0 < cellarFees.collect0) {
+                cellarFees.performance0 = cellarFees.collect0 - cellarFees.management0;
+            } else {
+                cellarFees.management0 = cellarFees.collect0;
+                cellarFees.performance0 = 0;
+            }
         }
         if (fee1 > cellarFees.collect1) {
             fee1 = cellarFees.collect1;
+            if (cellarFees.management1 < cellarFees.collect1) {
+                cellarFees.performance1 = cellarFees.collect1 - cellarFees.management1;
+            } else {
+                cellarFees.management1 = cellarFees.collect1;
+                cellarFees.performance1 = 0;
+            }
         }
 
         if (fee0 > 0) {

--- a/contracts/CellarPoolShareLimitETHUSDT.sol
+++ b/contracts/CellarPoolShareLimitETHUSDT.sol
@@ -430,8 +430,12 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
             fee0 += mFee0;
             fee1 += mFee1;
         }
-        fee0 += (balance0 * performanceFee) / FEEDOMINATOR;
-        fee1 += (balance1 * performanceFee) / FEEDOMINATOR;
+        uint256 mgmtFee0 = fee0;
+        uint256 mgmtFee1 = fee1;
+        uint256 perfFee0 = (balance0 * performanceFee) / FEEDOMINATOR;
+        uint256 perfFee1 = (balance1 * performanceFee) / FEEDOMINATOR;
+        fee0 += perfFee0;
+        fee1 += perfFee1;
         if (fee0 > balance0) {
             fee0 = balance0;
         }
@@ -447,7 +451,16 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
         }
         (uint256 investedAmount0, uint256 investedAmount1) = invest(sqrtPriceX96);
 
-        emit Reinvest(balance0, balance1, investedAmount0, investedAmount1);
+        emit Reinvest(
+            balance0,
+            balance1,
+            mgmtFee0,
+            mgmtFee1,
+            perfFee0,
+            perfFee1,
+            investedAmount0,
+            investedAmount1
+        );
     }
 
     function rebalance(CellarTickInfo[] memory _cellarTickInfo) external notLocked(msg.sender) {
@@ -469,9 +482,20 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
                 recipient: address(this),
                 deadline: type(uint256).max
             });
-        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, UintPair memory collectedFee) =
+
+        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, CellarFees memory cellarFees) =
             _removeLiquidity(removeParams);
         lastManageTimestamp = block.timestamp;
+
+        uint256 fee0 = cellarFees.management0 + cellarFees.performance0;
+        uint256 fee1 = cellarFees.management1 + cellarFees.performance1;
+        if (fee0 > cellarFees.collect0) {
+            fee0 = cellarFees.collect0;
+        }
+        if (fee1 > cellarFees.collect1) {
+            fee1 = cellarFees.collect1;
+        }
+
         if (fee0 > 0) {
             IERC20(token0).safeTransfer(_owner, fee0);
         }
@@ -497,7 +521,16 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
 
         (uint256 investedAmount0, uint256 investedAmount1) = invest(sqrtPriceX96);
 
-        emit Rebalance(collectedFee.a, collectedFee.b, investedAmount0, investedAmount1);
+        emit Rebalance(
+            cellarFees.collect0,
+            cellarFees.collect1,
+            cellarFees.management0,
+            cellarFees.management1,
+            cellarFees.performance0,
+            cellarFees.performance1,
+            investedAmount0,
+            investedAmount1
+        );
     }
 
     function setValidator(address _validator, bool value) external override {
@@ -941,7 +974,7 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
             uint256 outAmount0,
             uint256 outAmount1,
             uint128 liquiditySum,
-            UintPair memory collectedFee
+            CellarFees memory cellarFees
         )
     {
         CellarTickInfo[] memory _cellarTickInfo = cellarTickInfo;
@@ -992,23 +1025,18 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
                         amount1Max: type(uint128).max
                     })
                 );
-            collectedFee.a += collectAmount.a - amount.a;
-            collectedFee.b += collectAmount.b - amount.b;
+            cellarFees.collect0 += collectAmount.a - amount.a;
+            cellarFees.collect1 += collectAmount.b - amount.b;
             outAmount0 += amount.a;
             outAmount1 += amount.b;
             liquiditySum += outLiquidity;
             (amount.a, amount.b) = getManagementFee(_cellarTickInfo[i].tokenId, sqrtPriceX96, duration);
-            fee0 += amount.a;
-            fee1 += amount.b;
+            cellarFees.management0 += amount.a;
+            cellarFees.management1 += amount.b;
         }
-        fee0 += (collectedFee.a * performanceFee) / FEEDOMINATOR;
-        fee1 += (collectedFee.b * performanceFee) / FEEDOMINATOR;
-        if (fee0 > collectedFee.a) {
-            fee0 = collectedFee.a;
-        }
-        if (fee1 > collectedFee.b) {
-            fee1 = collectedFee.b;
-        }
+
+        cellarFees.performance0 += (cellarFees.collect0 * performanceFee) / FEEDOMINATOR;
+        cellarFees.performance1 += (cellarFees.collect1 * performanceFee) / FEEDOMINATOR;
     }
 
     function _beforeTokenTransfer(

--- a/contracts/CellarPoolShareLimitETHUSDT.sol
+++ b/contracts/CellarPoolShareLimitETHUSDT.sol
@@ -248,7 +248,7 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
         CellarRemoveParams calldata cellarParams
     ) external override nonReentrant notLocked(msg.sender) {
         require(block.timestamp <= cellarParams.deadline);
-        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, , ) =
+        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, ) =
             _removeLiquidity(cellarParams);
         _burn(msg.sender, cellarParams.tokenAmount);
 
@@ -447,7 +447,7 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
         }
         (uint256 investedAmount0, uint256 investedAmount1) = invest(sqrtPriceX96);
 
-        emit Reinvest(fee0, fee1, investedAmount0, investedAmount1);
+        emit Reinvest(balance0, balance1, investedAmount0, investedAmount1);
     }
 
     function rebalance(CellarTickInfo[] memory _cellarTickInfo) external notLocked(msg.sender) {
@@ -469,7 +469,7 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
                 recipient: address(this),
                 deadline: type(uint256).max
             });
-        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, uint256 fee0, uint256 fee1) =
+        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, UintPair memory collectedFee) =
             _removeLiquidity(removeParams);
         lastManageTimestamp = block.timestamp;
         if (fee0 > 0) {
@@ -497,7 +497,7 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
 
         (uint256 investedAmount0, uint256 investedAmount1) = invest(sqrtPriceX96);
 
-        emit Rebalance(fee0, fee1, investedAmount0, investedAmount1);
+        emit Rebalance(collectedFee.a, collectedFee.b, investedAmount0, investedAmount1);
     }
 
     function setValidator(address _validator, bool value) external override {
@@ -941,12 +941,10 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
             uint256 outAmount0,
             uint256 outAmount1,
             uint128 liquiditySum,
-            uint256 fee0,
-            uint256 fee1
+            UintPair memory collectedFee
         )
     {
         CellarTickInfo[] memory _cellarTickInfo = cellarTickInfo;
-        UintPair memory collectedFee;
         uint256 duration = block.timestamp - lastManageTimestamp;
         (uint160 sqrtPriceX96, , , , , , ) =
             IUniswapV3Pool(

--- a/contracts/CellarPoolShareLimitETHUSDT.sol
+++ b/contracts/CellarPoolShareLimitETHUSDT.sol
@@ -438,9 +438,21 @@ contract CellarPoolShareLimitETHUSDT is ICellarPoolShare, BlockLock {
         fee1 += perfFee1;
         if (fee0 > balance0) {
             fee0 = balance0;
+            if (mgmtFee0 < balance0) {
+                perfFee0 = balance0 - mgmtFee0;
+            } else {
+                mgmtFee0 = balance0;
+                perfFee0 = 0;
+            }
         }
         if (fee1 > balance1) {
             fee1 = balance1;
+            if (mgmtFee1 < balance1) {
+                perfFee1 = balance1 - mgmtFee1;
+            } else {
+                mgmtFee1 = balance1;
+                perfFee1 = 0;
+            }
         }
         lastManageTimestamp = block.timestamp;
         if (fee0 > 0) {

--- a/contracts/CellarPoolShareLimitUSDCETH.sol
+++ b/contracts/CellarPoolShareLimitUSDCETH.sol
@@ -248,7 +248,7 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
         CellarRemoveParams calldata cellarParams
     ) external override nonReentrant notLocked(msg.sender) {
         require(block.timestamp <= cellarParams.deadline);
-        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, , ) =
+        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, ) =
             _removeLiquidity(cellarParams);
         _burn(msg.sender, cellarParams.tokenAmount);
 
@@ -447,7 +447,7 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
         }
         (uint256 investedAmount0, uint256 investedAmount1) = invest(sqrtPriceX96);
 
-        emit Reinvest(fee0, fee1, investedAmount0, investedAmount1);
+        emit Reinvest(balance0, balance1, investedAmount0, investedAmount1);
     }
 
     function rebalance(CellarTickInfo[] memory _cellarTickInfo) external notLocked(msg.sender) {
@@ -469,7 +469,7 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
                 recipient: address(this),
                 deadline: type(uint256).max
             });
-        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, uint256 fee0, uint256 fee1) =
+        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, UintPair memory collectedFee) =
             _removeLiquidity(removeParams);
         lastManageTimestamp = block.timestamp;
         if (fee0 > 0) {
@@ -497,7 +497,7 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
 
         (uint256 investedAmount0, uint256 investedAmount1) = invest(sqrtPriceX96);
 
-        emit Rebalance(fee0, fee1, investedAmount0, investedAmount1);
+        emit Rebalance(collectedFee.a, collectedFee.b, investedAmount0, investedAmount1);
     }
 
     function setValidator(address _validator, bool value) external override {
@@ -941,12 +941,10 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
             uint256 outAmount0,
             uint256 outAmount1,
             uint128 liquiditySum,
-            uint256 fee0,
-            uint256 fee1
+            UintPair memory collectedFee
         )
     {
         CellarTickInfo[] memory _cellarTickInfo = cellarTickInfo;
-        UintPair memory collectedFee;
         uint256 duration = block.timestamp - lastManageTimestamp;
         (uint160 sqrtPriceX96, , , , , , ) =
             IUniswapV3Pool(

--- a/contracts/CellarPoolShareLimitUSDCETH.sol
+++ b/contracts/CellarPoolShareLimitUSDCETH.sol
@@ -491,9 +491,21 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
         uint256 fee1 = cellarFees.management1 + cellarFees.performance1;
         if (fee0 > cellarFees.collect0) {
             fee0 = cellarFees.collect0;
+            if (cellarFees.management0 < cellarFees.collect0) {
+                cellarFees.performance0 = cellarFees.collect0 - cellarFees.management0;
+            } else {
+                cellarFees.management0 = cellarFees.collect0;
+                cellarFees.performance0 = 0;
+            }
         }
         if (fee1 > cellarFees.collect1) {
             fee1 = cellarFees.collect1;
+            if (cellarFees.management1 < cellarFees.collect1) {
+                cellarFees.performance1 = cellarFees.collect1 - cellarFees.management1;
+            } else {
+                cellarFees.management1 = cellarFees.collect1;
+                cellarFees.performance1 = 0;
+            }
         }
 
         if (fee0 > 0) {

--- a/contracts/CellarPoolShareLimitUSDCETH.sol
+++ b/contracts/CellarPoolShareLimitUSDCETH.sol
@@ -438,9 +438,21 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
         fee1 += perfFee1;
         if (fee0 > balance0) {
             fee0 = balance0;
+            if (mgmtFee0 < balance0) {
+                perfFee0 = balance0 - mgmtFee0;
+            } else {
+                mgmtFee0 = balance0;
+                perfFee0 = 0;
+            }
         }
         if (fee1 > balance1) {
             fee1 = balance1;
+            if (mgmtFee1 < balance1) {
+                perfFee1 = balance1 - mgmtFee1;
+            } else {
+                mgmtFee1 = balance1;
+                perfFee1 = 0;
+            }
         }
         lastManageTimestamp = block.timestamp;
         if (fee0 > 0) {

--- a/contracts/CellarPoolShareLimitUSDCETH.sol
+++ b/contracts/CellarPoolShareLimitUSDCETH.sol
@@ -1047,8 +1047,8 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
             cellarFees.management1 += amount.b;
         }
 
-        cellarFees.performance0 += (cellarFees.collect0 * performanceFee) / FEEDOMINATOR;
-        cellarFees.performance1 += (cellarFees.collect1 * performanceFee) / FEEDOMINATOR;
+        cellarFees.performance0 = (cellarFees.collect0 * performanceFee) / FEEDOMINATOR;
+        cellarFees.performance1 = (cellarFees.collect1 * performanceFee) / FEEDOMINATOR;
     }
 
     function _beforeTokenTransfer(

--- a/contracts/CellarPoolShareLimitUSDCETH.sol
+++ b/contracts/CellarPoolShareLimitUSDCETH.sol
@@ -430,8 +430,12 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
             fee0 += mFee0;
             fee1 += mFee1;
         }
-        fee0 += (balance0 * performanceFee) / FEEDOMINATOR;
-        fee1 += (balance1 * performanceFee) / FEEDOMINATOR;
+        uint256 mgmtFee0 = fee0;
+        uint256 mgmtFee1 = fee1;
+        uint256 perfFee0 = (balance0 * performanceFee) / FEEDOMINATOR;
+        uint256 perfFee1 = (balance1 * performanceFee) / FEEDOMINATOR;
+        fee0 += perfFee0;
+        fee1 += perfFee1;
         if (fee0 > balance0) {
             fee0 = balance0;
         }
@@ -447,7 +451,16 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
         }
         (uint256 investedAmount0, uint256 investedAmount1) = invest(sqrtPriceX96);
 
-        emit Reinvest(balance0, balance1, investedAmount0, investedAmount1);
+        emit Reinvest(
+            balance0,
+            balance1,
+            mgmtFee0,
+            mgmtFee1,
+            perfFee0,
+            perfFee1,
+            investedAmount0,
+            investedAmount1
+        );
     }
 
     function rebalance(CellarTickInfo[] memory _cellarTickInfo) external notLocked(msg.sender) {
@@ -469,9 +482,20 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
                 recipient: address(this),
                 deadline: type(uint256).max
             });
-        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, UintPair memory collectedFee) =
+
+        (uint256 outAmount0, uint256 outAmount1, uint128 liquiditySum, CellarFees memory cellarFees) =
             _removeLiquidity(removeParams);
         lastManageTimestamp = block.timestamp;
+
+        uint256 fee0 = cellarFees.management0 + cellarFees.performance0;
+        uint256 fee1 = cellarFees.management1 + cellarFees.performance1;
+        if (fee0 > cellarFees.collect0) {
+            fee0 = cellarFees.collect0;
+        }
+        if (fee1 > cellarFees.collect1) {
+            fee1 = cellarFees.collect1;
+        }
+
         if (fee0 > 0) {
             IERC20(token0).safeTransfer(_owner, fee0);
         }
@@ -497,7 +521,16 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
 
         (uint256 investedAmount0, uint256 investedAmount1) = invest(sqrtPriceX96);
 
-        emit Rebalance(collectedFee.a, collectedFee.b, investedAmount0, investedAmount1);
+        emit Rebalance(
+            cellarFees.collect0,
+            cellarFees.collect1,
+            cellarFees.management0,
+            cellarFees.management1,
+            cellarFees.performance0,
+            cellarFees.performance1,
+            investedAmount0,
+            investedAmount1
+        );
     }
 
     function setValidator(address _validator, bool value) external override {
@@ -941,7 +974,7 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
             uint256 outAmount0,
             uint256 outAmount1,
             uint128 liquiditySum,
-            UintPair memory collectedFee
+            CellarFees memory cellarFees
         )
     {
         CellarTickInfo[] memory _cellarTickInfo = cellarTickInfo;
@@ -992,23 +1025,18 @@ contract CellarPoolShareLimitUSDCETH is ICellarPoolShare, BlockLock {
                         amount1Max: type(uint128).max
                     })
                 );
-            collectedFee.a += collectAmount.a - amount.a;
-            collectedFee.b += collectAmount.b - amount.b;
+            cellarFees.collect0 += collectAmount.a - amount.a;
+            cellarFees.collect1 += collectAmount.b - amount.b;
             outAmount0 += amount.a;
             outAmount1 += amount.b;
             liquiditySum += outLiquidity;
             (amount.a, amount.b) = getManagementFee(_cellarTickInfo[i].tokenId, sqrtPriceX96, duration);
-            fee0 += amount.a;
-            fee1 += amount.b;
+            cellarFees.management0 += amount.a;
+            cellarFees.management1 += amount.b;
         }
-        fee0 += (collectedFee.a * performanceFee) / FEEDOMINATOR;
-        fee1 += (collectedFee.b * performanceFee) / FEEDOMINATOR;
-        if (fee0 > collectedFee.a) {
-            fee0 = collectedFee.a;
-        }
-        if (fee1 > collectedFee.b) {
-            fee1 = collectedFee.b;
-        }
+
+        cellarFees.performance0 += (cellarFees.collect0 * performanceFee) / FEEDOMINATOR;
+        cellarFees.performance1 += (cellarFees.collect1 * performanceFee) / FEEDOMINATOR;
     }
 
     function _beforeTokenTransfer(

--- a/contracts/interfaces.sol
+++ b/contracts/interfaces.sol
@@ -594,6 +594,15 @@ interface ICellarPoolShare is IERC20 {
         uint256 b;
     }
 
+    struct CellarFees {
+        uint256 collect0;
+        uint256 collect1;
+        uint256 management0;
+        uint256 management1;
+        uint256 performance0;
+        uint256 performance1;
+    }
+
     event AddedLiquidity(
         address indexed token0,
         address indexed token1,
@@ -613,6 +622,10 @@ interface ICellarPoolShare is IERC20 {
     event Reinvest (
         uint256 fees0,
         uint256 fees1,
+        uint256 managementFee0,
+        uint256 managementFee1,
+        uint256 performanceFee0,
+        uint256 performanceFee1,
         uint256 amount0,
         uint256 amount1
     );
@@ -620,6 +633,10 @@ interface ICellarPoolShare is IERC20 {
     event Rebalance (
         uint256 fees0,
         uint256 fees1,
+        uint256 managementFee0,
+        uint256 managementFee1,
+        uint256 performanceFee0,
+        uint256 performanceFee1,
         uint256 amount0,
         uint256 amount1
     );


### PR DESCRIPTION
This PR updates the `Reinvest` and `Rebalance` events to emit the correct fee information. Previously we were sending the 'performance fee' transferred to the contract owner. With this change the actual fee collected from providing liquidity is emitted.

